### PR TITLE
✨ feat: 퀴즈 페이지 UI와 드래그앤드롭 구현

### DIFF
--- a/src/pages/graph/graph.jsx
+++ b/src/pages/graph/graph.jsx
@@ -1,16 +1,20 @@
-import GraphButton from "../../components/graph/graphButton";
-import * as G from "../../styles/graph/graph";
-import GraphFlow from "../../components/graph/graphFlow";
+import styled from "styled-components";
+import colors from "../../styles/common/colors";
+
+const GraphContainer = styled.div`
+  width: 76vw;
+  height: 43.4vw;
+  border-radius: 2vw;
+  background: ${colors.white};
+  margin-top: 1.1vw;
+`;
 
 const Graph = () => {
-    return (
-        <div className="pageContainer">
-            <G.GraphContainer>
-                <GraphFlow />
-                <GraphButton />
-            </G.GraphContainer>
-        </div>
-    )
-}
+  return (
+    <div className="pageContainer">
+      <GraphContainer></GraphContainer>
+    </div>
+  );
+};
 
 export default Graph;

--- a/src/pages/graph/graph.jsx
+++ b/src/pages/graph/graph.jsx
@@ -1,18 +1,14 @@
-import styled from "styled-components";
-import colors from "../../styles/common/colors";
-
-const GraphContainer = styled.div`
-  width: 76vw;
-  height: 43.4vw;
-  border-radius: 2vw;
-  background: ${colors.white};
-  margin-top: 1.1vw;
-`;
+import GraphButton from "../../components/graph/graphButton";
+import * as G from "../../styles/graph/graph";
+import GraphFlow from "../../components/graph/graphFlow";
 
 const Graph = () => {
   return (
     <div className="pageContainer">
-      <GraphContainer></GraphContainer>
+      <G.GraphContainer>
+        <GraphFlow />
+        <GraphButton />
+      </G.GraphContainer>
     </div>
   );
 };

--- a/src/pages/quiz/qna.jsx
+++ b/src/pages/quiz/qna.jsx
@@ -1,17 +1,173 @@
-import { useState } from "react";
+import { useEffect, useState, useRef } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
 import Modal from "../../components/quiz/modal/modal";
+import * as L from "../../styles/list/list";
 import * as Q from "../../styles/quiz/quiz";
 
 const Qna = () => {
-    const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const { id } = useParams(); // 퀴즈 ID
+  const [searchParams] = useSearchParams();
+  const mode = searchParams.get("mode"); // // 퀴즈레벨 파라미터 가져오서 저장(쉬움모드 or 어려움모드)
+  const [currentQuizNum, setCurrentQuizNum] = useState(1);
+  const [isCorrect, setIsCorrect] = useState(false);
 
-    return (
-        <div className="pageContainer">
-            <Q.CloseButton onClick={() => setIsOpen(true)}>정답 확인</Q.CloseButton>
+  // 드래그앤드롭 상태변수들
+  const [dragList, setDragList] = useState([]); // 드래그 가능한 단어들
+  const [droppedList, setDroppedList] = useState([]); // 드롭된 정답 슬롯
+  const dragItemRef = useRef(null); // 현재 드래그 중인 단어 인덱스
+  const [hiddenIndices, setHiddenIndices] = useState([]);
 
-            {isOpen && <Modal onClose={() => setIsOpen(false)} />}
-        </div>
-    )
-}
+  // ✅ 더미 데이터
+  const dummyData = {
+    questions: [
+      {
+        shuffled: ["개를", "좋아한다", "나는", "정말"],
+        answer: ["나는", "개를", "정말", "좋아한다"],
+      },
+      {
+        shuffled: ["강아지를", "보면", "웃는", "사람이", "많다"],
+        answer: ["사람이", "강아지를", "보면", "웃는", "많다"],
+      },
+    ],
+  };
+
+  // 통신 연결 시 주석 해제
+  // useEffect(() => {
+  //   if (data && data?.questions?.length > 0) {
+  //     // 문제 받아오면 초기화
+  //     const currentQuestion = data.questions[currentQuizNum - 1];
+  //     setDragList(currentQuestion.shuffled);
+  //     setDroppedList(Array(currentQuestion.answer.length).fill("")); // 빈칸 초기화
+  //   }
+  // }, [data, currentQuizNum]);
+
+  useEffect(() => {
+    const currentQuestion = dummyData.questions[currentQuizNum - 1];
+    console.log(currentQuestion);
+
+    setDragList(currentQuestion.shuffled);
+    setDroppedList(Array(currentQuestion.answer.length).fill(""));
+  }, [currentQuizNum]);
+
+  const handleDragStart = (index) => {
+    dragItemRef.current = index;
+  };
+
+  const handleDrop = (dropIndex) => {
+    //const draggedIndex = dragItemRef.current;
+
+    const dragged = dragList[dragItemRef.current];
+    if (!dragged) return;
+
+    setDroppedList((prev) => {
+      const newList = [...prev];
+      if (newList[dropIndex] === "") {
+        newList[dropIndex] = dragged;
+        setDragList((prevList) => prevList.filter((word) => word !== dragged));
+      }
+      return newList;
+    });
+
+    // 드래그 참조값 초기화
+    dragItemRef.current = null;
+  };
+
+  const handleSlotClick = (index) => {
+    const removed = droppedList[index]; // 클릭한 단어 저장
+    if (removed === "") return; // 빈칸 클릭 방지
+
+    setDroppedList((prev) => {
+      const newList = [...prev];
+      newList[index] = ""; // 빈 문자열로 변경
+      return newList;
+    });
+
+    setDragList((prev) => [...prev, removed]);
+  };
+
+  // 정답확인버튼을 눌렀을 때
+  const handleCheckAnswer = () => {
+    const currentAnswer =
+      dummyData.questions[currentQuizNum - 1].answer.join("");
+    const userAnswer = droppedList.join("");
+    const result = currentAnswer === userAnswer;
+    setIsCorrect(result);
+    setIsOpen(true);
+  };
+  const handleCloseModal = () => {
+    setIsOpen(false);
+    if (isCorrect) {
+      setCurrentQuizNum((prev) => prev + 1); // 모달을 닫을 때 정답일 경우에만 다음 퀴즈로 이동
+    }
+  };
+
+  return (
+    <div className="pageContainer">
+      <L.ListContainer>
+        <Q.ResultContainer>
+          {/* answer 문자열값 텍스트 길이에 맞게 늘어나도록 스타일 조정 필요 */}
+          {/* {data?.questions?.map((question, qIdx) => (
+            <Q.DropItemContainer key={qIdx}>
+              {question.answer.map((word, idx) => (
+                <Q.DropItem
+                  key={idx}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={() => handleDrop(i)}
+                  onClick={() => handleSlotClick(i)}
+                ></Q.DropItem>
+              ))}
+            </Q.DropItemContainer>
+          ))} */}
+          <Q.DropItemContainer>
+            {droppedList.map((word, idx) => (
+              <Q.DropItem
+                key={idx}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={() => handleDrop(idx)}
+                onClick={() => handleSlotClick(idx)}
+              >
+                {word}
+              </Q.DropItem>
+            ))}
+          </Q.DropItemContainer>
+
+          <Q.CloseButton onClick={handleCheckAnswer}>정답 확인</Q.CloseButton>
+          <Q.QuizCount>{currentQuizNum} / 5</Q.QuizCount>
+        </Q.ResultContainer>
+        <Q.QuizBottomContainer>
+          {/* {data?.questions?.map((question, qIdx) => (
+            <Q.DraaggableItemContainer key={qIdx}>
+              {question.shuffled.map((word, idx) => (
+                <Q.DraaggableItem
+                  key={idx}
+                  draggable
+                  onDragStart={() => handleDragStart(i)}
+                >
+                  {word}
+                </Q.DraaggableItem>
+              ))}
+            </Q.DraaggableItemContainer>
+          ))} */}
+          <Q.DraaggableItemContainer>
+            {dragList.map((word, idx) =>
+              word ? ( // 드래그된 후 제거된 항목은 undefined나 null이 될 수 있음
+                <Q.DraaggableItem
+                  key={idx}
+                  draggable
+                  onDragStart={() => handleDragStart(idx)}
+                >
+                  {word}
+                </Q.DraaggableItem>
+              ) : null
+            )}
+          </Q.DraaggableItemContainer>
+        </Q.QuizBottomContainer>
+      </L.ListContainer>
+
+      {isOpen && <Modal onClose={handleCloseModal} />}
+    </div>
+  );
+};
 
 export default Qna;

--- a/src/routes/router.jsx
+++ b/src/routes/router.jsx
@@ -19,13 +19,13 @@ const router = createBrowserRouter([
     path: "/",
     element: <RootLayout />,
     children: [
-      { 
+      {
         path: "list",
         element: <ListPage />,
       },
       {
         path: "graph/:id",
-        element: <GraphPage />
+        element: <GraphPage />,
       },
       {
         path: "quiz/:id",
@@ -36,17 +36,16 @@ const router = createBrowserRouter([
           },
           {
             path: "qna",
-            element: <QnaPage />
+            element: <QnaPage />,
           },
           {
             path: "result",
-            element: <ResultPage />
-          }
-        ]
-      }
+            element: <ResultPage />,
+          },
+        ],
+      },
     ],
   },
 ]);
-
 
 export default router;

--- a/src/styles/quiz/quiz.jsx
+++ b/src/styles/quiz/quiz.jsx
@@ -3,126 +3,198 @@ import colors from "../common/colors";
 
 // quiz.jsx
 export const QuizContainer = styled.div`
-    margin-top: 13.6vw;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 3vw;
-`
+  margin-top: 13.6vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3vw;
+`;
 
 export const QuizP = styled.p`
-    font-size: 1.8vw;
-    font-weight: 400;
-    color: ${colors.gray3};
-    font-family: 'Ownglyph_meetme-Rg';
-`
+  font-size: 1.8vw;
+  font-weight: 400;
+  color: ${colors.gray3};
+  font-family: "Ownglyph_meetme-Rg";
+`;
 
 export const ButtonContainer = styled.div`
-    display: flex;
-    gap: 3vw;
-`
+  display: flex;
+  gap: 3vw;
+`;
 
 export const StageButton = styled.button`
-    width: 10vw;
-    height: 5vw;
-    border-radius: 2.5vw;
-    background: ${colors.white};
-    font-family: 'Ownglyph_meetme-Rg';
-    font-size: 2vw;
-    font-weight: 400;
-    color: ${colors.brown};
-`
+  width: 10vw;
+  height: 5vw;
+  border-radius: 2.5vw;
+  background: ${colors.white};
+  font-family: "Ownglyph_meetme-Rg";
+  font-size: 2vw;
+  font-weight: 400;
+  color: ${colors.brown};
+`;
 
 // modal.jsx
 export const ModalContainer = styled.div`
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 40vw;
-    min-height: 30vw;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 2.2vw 7.5vw 1.75vw 7.5vw;
-    background: ${colors.white};
-    border-radius: 2vw;
-`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40vw;
+  min-height: 30vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.2vw 7.5vw 1.75vw 7.5vw;
+  background: ${colors.white};
+  border-radius: 2vw;
+`;
 
 export const ModalP = styled.p`
-    font-size: 2vw;
-    font-weight: 400;
-    color: ${colors.black};
-    font-family: 'Ownglyph_meetme-Rg';
-`
+  font-size: 2vw;
+  font-weight: 400;
+  color: ${colors.black};
+  font-family: "Ownglyph_meetme-Rg";
+`;
 
 export const ModalImg = styled.img`
-    width: 7.3vw;
-    height: 7.1vw;
-    margin: 1.25vw 0 2vw 0;
-`
+  width: 7.3vw;
+  height: 7.1vw;
+  margin: 1.25vw 0 2vw 0;
+`;
 
 export const ModalP2 = styled(ModalP)`
-    font-size: 1.5vw;
-    color: ${colors.gray4};
-    font-weight: 400;
-    font-family: 'Ownglyph_meetme-Rg';
-    line-height: 175%;
-    text-align: center;
-    margin-bottom: 2vw;
-`
+  font-size: 1.5vw;
+  color: ${colors.gray4};
+  font-weight: 400;
+  font-family: "Ownglyph_meetme-Rg";
+  line-height: 175%;
+  text-align: center;
+  margin-bottom: 2vw;
+`;
 
 export const CloseButton = styled.button`
-    width: 6.5vw;
-    height: 3.4vw;
-    border-radius: 1.7vw;
-    background: ${colors.orange};
-    font-size: 1.8vw;
-    font-weight: 400;
-    color: ${colors.white};
-    font-family: 'Ownglyph_meetme-Rg';
-`
+  width: 6.5vw;
+  height: 3.4vw;
+  border-radius: 1.7vw;
+  background: ${colors.orange};
+  font-size: 1.5vw;
+  font-weight: 400;
+  color: ${colors.white};
+  font-family: "Ownglyph_meetme-Rg";
+  margin-bottom: 1vw;
+`;
 
 // result.jsx
 export const ResultContainer = styled.div`
-    width: 100%;
-    height: 33.5vw;
-    border-radius: 3vw;
-    background: ${colors.white};
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin: 2vw 0 3vw 0;
-`
+  position: relative;
+  width: 100%;
+  height: 33.5vw;
+  border-radius: 3vw;
+  background: ${colors.white};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 2vw 0 3vw 0;
+`;
 
 export const InnerResultContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 3vw;
-`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3vw;
+`;
 
 export const ResultP = styled.p`
-    font-size: 3.5vw;
-    font-weight: 400;
-    color: ${colors.brown};
-    font-family: 'Ownglyph_meetme-Rg';
-    text-align: center;
-`
+  font-size: 3.5vw;
+  font-weight: 400;
+  color: ${colors.brown};
+  font-family: "Ownglyph_meetme-Rg";
+  text-align: center;
+`;
 
 export const ResultButtonContainer = styled.div`
-    display: flex;
-    gap: 3vw;
-`
+  display: flex;
+  gap: 3vw;
+`;
 
 export const ResultButton = styled.button`
-    width: 15.7vw;
-    height: 5vw;
-    border-radius: 2.5vw;
-    outline: 0.2vw solid ${colors.orange2};
-    background: ${colors.white};
-    font-size: 2vw;
-    font-weight: 400;
-    color: ${colors.orange2};
-    font-family: 'Ownglyph_meetme-Rg';
-`
+  width: 15.7vw;
+  height: 5vw;
+  border-radius: 2.5vw;
+  outline: 0.2vw solid ${colors.orange2};
+  background: ${colors.white};
+  font-size: 2vw;
+  font-weight: 400;
+  color: ${colors.orange2};
+  font-family: "Ownglyph_meetme-Rg";
+`;
+
+// qna.jsx
+export const QuizCount = styled.div`
+  position: absolute;
+  right: 3vw;
+  bottom: 0;
+  color: ${colors.brown};
+  font-size: 3.5vw;
+  font-family: "Ownglyph_meetme-Rg";
+`;
+
+export const QuizBottomContainer = styled.div`
+  width: 100%;
+  height: 6vw;
+  background-color: ${colors.white};
+  border-radius: 3vw;
+  padding: 1vw 3vw;
+  display: flex;
+  justify-content: space-around;
+  gap: 2vw;
+`;
+export const DraaggableItemContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-around;
+`;
+
+export const DraaggableItem = styled.div`
+  width: auto;
+  height: 100%;
+  border-radius: 50px;
+  background: #f0f0f0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: "Ownglyph_meetme-Rg";
+  font-size: 1.5vw;
+  padding: 1.2vw;
+`;
+
+export const DropItemContainer = styled.div`
+  max-width: 100%;
+  height: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 3vw;
+  gap: 2vw;
+`;
+
+export const DropItem = styled.div`
+  min-width: 8vw;
+
+  border-radius: 50px;
+  border: 3px solid ${colors.orange2};
+
+  background: ${colors.white};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: "Ownglyph_meetme-Rg";
+  font-size: 1.5vw;
+  padding: 1.2vw;
+`;


### PR DESCRIPTION
## 🚀 관련 이슈
- close #8 

## 🔑 작업 내용
퀴즈 페이지 UI 구현과 드래그앤드롭 코드 추가

## 📷 스크린샷
- 퀴즈 페이지 초기 화면
<img width="1459" alt="image" src="https://github.com/user-attachments/assets/689bb80e-63fc-4d11-9114-76904a4005ac" />
- 드롭한 화면 
드롭된 칸에서 글자박스 클릭하면 다시 원래의 위치로 돌아감
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/43ef2e9f-8d0f-49df-a60d-e5c140620e3e" />
- 정답일 경우 다음 문제로 이동
<img width="1404" alt="image" src="https://github.com/user-attachments/assets/2b51aadf-3415-457a-a0bb-e26a10d33c9e" />


## 🌐 공유 사항 to 리뷰어
추후 모달 수정 필요

## 🚨 이슈 사항