### PR TITLE
✨ feat: 그래프 페이지 tts 기능 추가

### DIFF
--- a/src/components/graph/graphNode.jsx
+++ b/src/components/graph/graphNode.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Handle, Position, useUpdateNodeInternals, useReactFlow } from "reactflow";
 import * as G from "../../styles/graph/graph";
 import { levelStyles } from "../../mocks/graphData";
 import { useEditMode } from "../../contexts/editModeContext";
 import Sound from "../../assets/images/graph/sound.png";
+import { speak, stop } from "../../utils/tts";
 
 const GraphNode = ({ id, data }) => {
   const { label, level, description, image, onContextMenu } = data;
@@ -17,6 +18,11 @@ const GraphNode = ({ id, data }) => {
     }
   };
 
+  // tts
+  const handleSoundClick = useCallback(() => {
+    speak(description);
+  }, [description]);
+
   const ref = useRef(null);
   const updateNodeInternals = useUpdateNodeInternals();
   const { getZoom } = useReactFlow();
@@ -29,13 +35,20 @@ const GraphNode = ({ id, data }) => {
   useEffect(() => {
     const checkZoom = () => {
       const currentZoom = getZoom();
-      setIsZoomedIn(currentZoom >= style.zoom);
+      const zoomCheck = currentZoom >= style.zoom;
+  
+      if (!zoomCheck && isZoomedIn) {
+        stop();
+      }
+  
+      setIsZoomedIn(zoomCheck);
     };
-
+  
     checkZoom();
     const interval = setInterval(checkZoom, 300);
     return () => clearInterval(interval);
-  }, [getZoom, style.zoom]);
+  }, [getZoom, style.zoom, isZoomedIn]);
+  
 
   return (
     <G.NodeWrapper
@@ -51,7 +64,7 @@ const GraphNode = ({ id, data }) => {
         <G.NodeLeftContainer>
           <G.NodeTitleContainer nodeTitleContainerGap={style.nodeTitleContainerGap}>
             {isZoomedIn && 
-              <G.SoundImgContainer soundImgContainerWidth={style.soundImgContainerWidth} soundImgContainerHeight={style.soundImgContainerHeight}>
+              <G.SoundImgContainer soundImgContainerWidth={style.soundImgContainerWidth} soundImgContainerHeight={style.soundImgContainerHeight} onClick={handleSoundClick}>
                 <G.SoundImg src={Sound} alt="sound" soundImgWidth={style.soundImgWidth} />
               </G.SoundImgContainer>
             }

--- a/src/utils/tts.jsx
+++ b/src/utils/tts.jsx
@@ -1,0 +1,18 @@
+export const speak = (text, lang = "ko-KR") => {
+    if (!text || typeof window === "undefined") return;
+  
+    if (window.speechSynthesis.speaking) {
+      window.speechSynthesis.cancel();
+    }
+  
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = lang;
+    window.speechSynthesis.speak(utterance);
+  };
+  
+export const stop = () => {
+    if (typeof window !== "undefined" && window.speechSynthesis.speaking) {
+      window.speechSynthesis.cancel();
+    }
+};
+  


### PR DESCRIPTION
## 🚀 관련 이슈
- close #25 

## 🔑 작업 내용
- 그래프 페이지에서 노드의 소리 아이콘 클릭 시, 상세 설명 읽어주는 tts 기능 추가
- 음성 나오는 중에 노드 축소 시, tts 기능 종료

## 📷 스크린샷
<img width="1512" alt="스크린샷 2025-04-22 오후 2 08 08" src="https://github.com/user-attachments/assets/b87684bb-9a01-46f6-80c0-2531a4c42237" />

## 🌐 공유 사항 to 리뷰어

## 🚨 이슈 사항
