### PR TITLE
♻️ refactor: 지식 그래프 노드 색상 변경

### DIFF
--- a/src/components/graph/graphFlow.jsx
+++ b/src/components/graph/graphFlow.jsx
@@ -23,6 +23,8 @@ const GraphFlow = ({ isClickChatbotBtn, setIsClickChatbotBtn, nodeData, edgeData
   const [selectedNode, setSelectedNode] = useState(null);
   const [nodeDetail, setNodeDetail] = useState(null);
   const { id: graphId } = useParams();
+  const [backgroundColor, setBackgroundColor] = useState("colors.white");
+  const [isZoomedIn, setIsZoomedIn] = useState(false);
 
   const { get, data, loading, error } = useGet();
 
@@ -94,6 +96,18 @@ const GraphFlow = ({ isClickChatbotBtn, setIsClickChatbotBtn, nodeData, edgeData
           includeSentence: node.includeSentence,
           image: node.image,
           onContextMenu: handleNodeRightClick,
+          onZoomStateChange: (nextZoomState) => {
+            setIsZoomedIn(prev => {
+              if (prev !== nextZoomState) {
+                if (isEditMode) {
+                  setBackgroundColor(nextZoomState ? colors.white : colors.gray5);
+                } else {
+                  setBackgroundColor(nextZoomState ? colors.mainBlue : colors.white);
+                }
+              }
+              return nextZoomState;
+            });
+          },
         },
         position: { x: node.x, y: node.y },
         draggable: true,
@@ -173,7 +187,7 @@ const GraphFlow = ({ isClickChatbotBtn, setIsClickChatbotBtn, nodeData, edgeData
   };
 
   const handleNodeDoubleClick = useCallback((event, node) => {
-    setSelectedNode(node);
+    // setSelectedNode(node);
     
     setTimeout(() => {
       get(`/graph/${graphId}/${node.id}`);
@@ -188,8 +202,17 @@ const GraphFlow = ({ isClickChatbotBtn, setIsClickChatbotBtn, nodeData, edgeData
         zoom,
         duration: 500,
       });
+      setBackgroundColor(isEditMode ? colors.white : colors.mainBlue);
     }
-}, [get, graphId]);
+}, [get, graphId, isEditMode]);
+
+useEffect(() => {
+  if (isEditMode) {
+    setBackgroundColor(isZoomedIn ? colors.white : colors.gray5);
+  } else {
+    setBackgroundColor(isZoomedIn ? colors.mainBlue : colors.white);
+  }
+}, [isEditMode, isZoomedIn]);
 
   return (
     <G.GraphLayout>
@@ -206,6 +229,7 @@ const GraphFlow = ({ isClickChatbotBtn, setIsClickChatbotBtn, nodeData, edgeData
             onInit={onInit}
             onNodeDoubleClick={handleNodeDoubleClick}
             proOptions={{ hideAttribution: true }}
+            style={{ backgroundColor }}
           >
             <Controls />
           </ReactFlow>

--- a/src/components/graph/graphNode.jsx
+++ b/src/components/graph/graphNode.jsx
@@ -7,7 +7,7 @@ import Sound from "../../assets/images/graph/sound.png";
 import { useTTS } from "../../contexts/TTSContext";
 
 const GraphNode = ({ id, data }) => {
-  const { label, level, group, includeSentence, image, onContextMenu } = data;
+  const { label, level, group, includeSentence, image, onContextMenu, onZoomStateChange } = data;
   const style = levelStyles[level] || levelStyles[1];
   const style2 = groupStyles[group] || groupStyles[1];
   const { isEditMode } = useEditMode();
@@ -44,13 +44,18 @@ const GraphNode = ({ id, data }) => {
         stop();
       }
   
+      if (zoomCheck !== isZoomedIn) {
       setIsZoomedIn(zoomCheck);
-    };
-  
-    checkZoom();
-    const interval = setInterval(checkZoom, 300);
-    return () => clearInterval(interval);
-  }, [getZoom, style.zoom, isZoomedIn, stop]);
+      if (typeof onZoomStateChange === "function") {
+        onZoomStateChange(zoomCheck);
+      }
+    }
+  };
+
+  checkZoom();
+  const interval = setInterval(checkZoom, 300);
+  return () => clearInterval(interval);
+}, [getZoom, style.zoom, isZoomedIn, stop, onZoomStateChange]);
   
 
   return (

--- a/src/styles/common/colors.js
+++ b/src/styles/common/colors.js
@@ -1,5 +1,6 @@
 const colors = {
     mainYellow: "#FFD839",
+    mainBlue: "#8EE2FF",
     subYellow: "#FFF7D6",
     green: "#00B718",
     red: "#FF3838",
@@ -14,16 +15,16 @@ const colors = {
     black: "#000000",
     white: "#FFFFFF",
 
-    groupId1: "#FF3838",
-    groupId2: "#FF9400",
-    groupId3: "#FFD839",
-    groupId4: "#00B718",
-    groupId5: "#1500FF",
-    groupId6: "#7700FF",
-    groupId7: "#FF00FB",
-    groupId8: "#FF006A",
-    groupId9: "#00AAFF",
-    groupId10: "#00FF44",
+    groupId1: "#FFB3BA",
+    groupId2: "#FAD0C4",
+    groupId3: "#FFF9C4",
+    groupId4: "#B5F2D4",
+    groupId5: "#AEC6CF",
+    groupId6: "#C5C9F9",
+    groupId7: "#FFDAC1",
+    groupId8: "#E2F0CB",
+    groupId9: "#FAD0C4",
+    groupId10: "#D5AAFF",
 };
 
 export default colors;

--- a/src/styles/common/theme.js
+++ b/src/styles/common/theme.js
@@ -2,7 +2,7 @@ import colors from "./colors";
 
 export const lightTheme = {
     global: {
-        background: colors.mainYellow,
+        background: colors.mainBlue,
     },
     components: {
         innerHeaderContainer: {

--- a/src/styles/graph/graph.jsx
+++ b/src/styles/graph/graph.jsx
@@ -73,6 +73,7 @@ export const GraphFlowContainer = styled.div`
   background: ${({ theme }) =>
     theme.components?.graphFlowContainer?.background || colors.white};
   position: relative;
+  overflow: hidden;
 `;
 
 // graphNode.jsx


### PR DESCRIPTION
## 🚀 관련 이슈

## 🔑 작업 내용
지식 그래프 노드  색상 변경

## 📷 스크린샷
<img width="1512" alt="스크린샷 2025-05-20 오후 12 30 38" src="https://github.com/user-attachments/assets/742b8467-0837-4da5-a0ef-9e0bbc617287" />


## 🌐 공유 사항 to 리뷰어
노드 더블 클릭 시 나오는 스타일 적용은 아직 안했습니다.
엣지(관계명)도 스타일링 적용해야 할 것 같습니다.

## 🚨 이슈 사항
